### PR TITLE
EM Bug Fixes, EL Phase Name in MM Tooltip, misc fixes

### DIFF
--- a/_retail_/Interface/AddOns/EpsilonLib/Modules/UnitPopupMenus.lua
+++ b/_retail_/Interface/AddOns/EpsilonLib/Modules/UnitPopupMenus.lua
@@ -117,35 +117,13 @@ for k, v in pairs(cheatStatus) do
 end
 
 local function cheatToggleListener(self, event, message)
-	if event == "CHAT_MSG_ADDON" then
-		message = message:sub(5) -- remove the addon command part
-	end
-	local rawmsg = message:gsub("|", "||")
-	-- Cheat Toggle Listener
 	if cheatMessages[message] then
 		local table = cheatMessages[message]
 		cheatStatus[table.ref].status = table.type
 		return false
 	end
 end
-
-ChatFrame_AddMessageEventFilter("CHAT_MSG_ADDON", cheatToggleListener)
-ChatFrame_AddMessageEventFilter("CHAT_MSG_SYSTEM", cheatToggleListener)
-ChatFrame_AddMessageEventFilter("CHAT_MSG_ACHIEVEMENT", cheatToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_BN_WHISPER_INFORM", cheatToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_COMBAT_XP_GAIN", cheatToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_COMBAT_HONOR_GAIN", cheatToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_COMBAT_FACTION_CHANGE", cheatToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_TRADESKILLS", cheatToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_OPENING", cheatToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_PET_INFO", cheatToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_COMBAT_MISC_INFO", cheatToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_BG_SYSTEM_HORDE", cheatToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_BG_SYSTEM_ALLIANCE", cheatToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_BG_SYSTEM_NEUTRAL", cheatToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_TARGETICONS", cheatToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_BN_CONVERSATION_NOTICE", cheatToggleListener);
-
+EpsiLib.EventManager:AddCommandFilter(cheatToggleListener)
 
 -- util references:
 -- UnitIsConnected(unit)

--- a/_retail_/Interface/AddOns/EpsilonLib/Modules/misc.lua
+++ b/_retail_/Interface/AddOns/EpsilonLib/Modules/misc.lua
@@ -1,7 +1,47 @@
 local EpsilonLib, EpsiLib = ...;
 
-
 -- Add PhaseID to MiniMap Zone Tooltip
+local grey = CreateColor(0.8, 0.8, 0.8)
+local phaseNameOverrides = {
+	[169] = "Main Phase",
+}
+
+local lastPhaseInfo = {
+	name = nil,
+	id = 169,
+	color = nil
+}
+
+local phaseTextFormat = "%s " .. grey:WrapTextInColorCode("(%s)")
+
 hooksecurefunc("Minimap_SetTooltip", function()
-	GameTooltip:AddDoubleLine("Phase: ", C_Epsilon.GetPhaseId(), nil, nil, nil, 1, 1, 1)
+	local phaseID = tonumber(C_Epsilon.GetPhaseId())
+	local name = lastPhaseInfo.name
+
+	if phaseNameOverrides[phaseID] then name = phaseNameOverrides[phaseID] end
+
+	local text
+	if not name then
+		text = phaseID
+	else
+		if lastPhaseInfo.color then name = WrapTextInColorCode(name, lastPhaseInfo.color) end
+		text = phaseTextFormat:format(name, phaseID)
+	end
+
+	GameTooltip:AddDoubleLine("Phase: ", text, nil, nil, nil, 1, 1, 1)
+	GameTooltip:Show() -- To fix the displayed padding
 end)
+
+local function joinedPhaseListener(self, event, message)
+	--  You have joined phase |cff00CCFF[Prophecy - Fall of Lordaeron - 100]|r.
+	local name, phase = message:match("^You have joined phase |cff00CCFF%[(.+) %- (%d+)%]|r%.")
+	lastPhaseInfo.name = name
+	lastPhaseInfo.id = tonumber(phase)
+end
+local function leftPhaseListener(self, event, message)
+	lastPhaseInfo.name = "Main Phase"
+	lastPhaseInfo.id = 169
+end
+
+EpsiLib.EventManager:RegisterSimpleCommandWatcher("You have joined phase |cff", joinedPhaseListener)
+EpsiLib.EventManager:RegisterSimpleCommandWatcher("You have been returned to the main world from phase |cff", leftPhaseListener)

--- a/_retail_/Interface/AddOns/EpsilonLib/Utils/EventManager.lua
+++ b/_retail_/Interface/AddOns/EpsilonLib/Utils/EventManager.lua
@@ -1,5 +1,12 @@
 local EpsilonLib, EpsiLib = ...;
 
+--- ---------------------------------------
+--- Epsilon Lib - Event Manager Systems
+--- ---------------------------------------
+
+--#region WoW Events Listeners & Callbacks
+--- Uses a single frame to handle all events & callbacks, versus making a new frame every time we want a module to watch for an event
+
 local eventFrame = CreateFrame("Frame")
 
 local _events = {}
@@ -65,5 +72,88 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
 		end
 	end
 end)
+
+--#endregion
+
+--#region Command Event Manager
+--- Watching for Command Replies & handling if needed - Mostly for static capture of data & logging
+
+
+local filter_events = {
+	"CHAT_MSG_ADDON",
+	"CHAT_MSG_SYSTEM",
+	"CHAT_MSG_ACHIEVEMENT",
+	"CHAT_MSG_BN_WHISPER_INFORM",
+	"CHAT_MSG_COMBAT_XP_GAIN",
+	"CHAT_MSG_COMBAT_HONOR_GAIN",
+	"CHAT_MSG_COMBAT_FACTION_CHANGE",
+	"CHAT_MSG_TRADESKILLS",
+	"CHAT_MSG_OPENING",
+	"CHAT_MSG_PET_INFO",
+	"CHAT_MSG_COMBAT_MISC_INFO",
+	"CHAT_MSG_BG_SYSTEM_HORDE",
+	"CHAT_MSG_BG_SYSTEM_ALLIANCE",
+	"CHAT_MSG_BG_SYSTEM_NEUTRAL",
+	"CHAT_MSG_TARGETICONS",
+	"CHAT_MSG_BN_CONVERSATION_NOTICE",
+}
+
+---Helper Util to quickly create a command reply filter through all the possible command reply channels, with proper handling of AddOn Commands
+---@param callback function The callback function to run on reply. You should pattern match first to make sure it's the reply you want.
+---@return function reference The callback provided in the input is wrapped, so is no longer valid for using in removal - This reference is the new, wrapped callback
+function _events:AddCommandFilter(callback)
+	if not callback then error("AddCommandFilter Syntax Error: No Callback given. Are you calling with a : ?") end
+	local function wrapper(self, event, message)
+		if event == "CHAT_MSG_ADDON" then
+			message = message:sub(5) -- remove the addon command part
+		end
+		return callback(nil, event, message)
+	end
+	for i = 1, #filter_events do
+		ChatFrame_AddMessageEventFilter(filter_events[i], wrapper)
+	end
+
+	return wrapper
+end
+
+---Removes a command filter by function reference from the return on AddCommandFilter
+---@param reference function
+function _events:RemoveCommandFilter(reference)
+	for i = 1, #filter_events do
+		ChatFrame_RemoveMessageEventFilter(filter_events[i], reference)
+	end
+end
+
+-- Simple Pattern -> Callback system
+local commandWatchers = {}
+
+---Registers a simple pattern match to callback on command replies.
+---@param pattern string The pattern that must be matched in order to run this callback
+---@param callback fun(self, event, message) The callback function, with the same args as a standard MessageEventFilter, except self is always nil
+---@return table reference The table reference for this new entry, which is a table housing the pattern & callback, which can then technically be modified live as well.
+function _events:RegisterSimpleCommandWatcher(pattern, callback)
+	local new_table = { pattern = pattern, callback = callback }
+	tinsert(commandWatchers, new_table)
+	return new_table
+end
+
+---Removes a simple command watcher by reference from the return on RegisterSimpleCommandWatcher
+---@param reference table
+function _events:DeleteSimpleCommandWatcher(reference)
+	tDeleteItem(commandWatchers, reference)
+end
+
+local function simpleCommandReplyListener(_, event, message)
+	for i = 1, #commandWatchers do
+		local data = commandWatchers[i]
+		if message:find(data.pattern) then
+			return data.callback(nil, event, message)
+		end
+	end
+end
+
+_events:AddCommandFilter(simpleCommandReplyListener)
+
+--#endregion
 
 EpsiLib.EventManager = _events

--- a/_retail_/Interface/AddOns/Epsilon_ChatToggle/ChatToggle.lua
+++ b/_retail_/Interface/AddOns/Epsilon_ChatToggle/ChatToggle.lua
@@ -305,17 +305,6 @@ local announceMessages = {
 	["|cff00CCFFGuild broadcasts are now |renabled|cff00CCFF.|r"] = function() setAnnounceToggled("guild", true) end,
 	["|cff00CCFFGuild broadcasts are now |rdisabled|cff00CCFF.|r"] = function() setAnnounceToggled("guild", false) end,
 }
---[[
-
-|cff00CCFFBroadcasts are now |rdisabled|cff00CCFF.|r
-|cff00CCFFEvent broadcasts are now |rdisabled|cff00CCFF.|r
-|cff00CCFFGuild broadcasts are now |rdisabled|cff00CCFF.|r
-
-|cff00CCFFBroadcasts are now |renabled|cff00CCFF.|r
-|cff00CCFFEvent broadcasts are now |renabled|cff00CCFF.|r
-|cff00CCFFGuild broadcasts are now |renabled|cff00CCFF.|r
-
-]]
 
 local function announceToggleListener(self, event, message)
 	-- Announce Toggle Listener
@@ -323,33 +312,24 @@ local function announceToggleListener(self, event, message)
 		announceMessages[message]()
 		return false
 	end
-
-	-- Ignore Filter --// Deprecated in favor of the server handling this instead, meaning it also respects announce via #main also!
-	--[[
-	if Epsilon_ChatToggle_Account.ignore then
-		local playerName = message:match("|Hplayer:(.-)|h")
-		if playerName then
-			if C_FriendList.IsIgnored(playerName) then
-				--print(playerName.." is Ignored. Message should be hidden.")
-				return true;
-			end
-		end
-	end
-	--]]
 end
 
-ChatFrame_AddMessageEventFilter("CHAT_MSG_SYSTEM", announceToggleListener)
-ChatFrame_AddMessageEventFilter("CHAT_MSG_ACHIEVEMENT", announceToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_BN_WHISPER_INFORM", announceToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_COMBAT_XP_GAIN", announceToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_COMBAT_HONOR_GAIN", announceToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_COMBAT_FACTION_CHANGE", announceToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_TRADESKILLS", announceToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_OPENING", announceToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_PET_INFO", announceToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_COMBAT_MISC_INFO", announceToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_BG_SYSTEM_HORDE", announceToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_BG_SYSTEM_ALLIANCE", announceToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_BG_SYSTEM_NEUTRAL", announceToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_TARGETICONS", announceToggleListener);
-ChatFrame_AddMessageEventFilter("CHAT_MSG_BN_CONVERSATION_NOTICE", announceToggleListener);
+if EpsilonLib and EpsilonLib.EventManager then
+	EpsilonLib.EventManager:AddCommandFilter(announceToggleListener)
+else
+	ChatFrame_AddMessageEventFilter("CHAT_MSG_SYSTEM", announceToggleListener)
+	ChatFrame_AddMessageEventFilter("CHAT_MSG_ACHIEVEMENT", announceToggleListener);
+	ChatFrame_AddMessageEventFilter("CHAT_MSG_BN_WHISPER_INFORM", announceToggleListener);
+	ChatFrame_AddMessageEventFilter("CHAT_MSG_COMBAT_XP_GAIN", announceToggleListener);
+	ChatFrame_AddMessageEventFilter("CHAT_MSG_COMBAT_HONOR_GAIN", announceToggleListener);
+	ChatFrame_AddMessageEventFilter("CHAT_MSG_COMBAT_FACTION_CHANGE", announceToggleListener);
+	ChatFrame_AddMessageEventFilter("CHAT_MSG_TRADESKILLS", announceToggleListener);
+	ChatFrame_AddMessageEventFilter("CHAT_MSG_OPENING", announceToggleListener);
+	ChatFrame_AddMessageEventFilter("CHAT_MSG_PET_INFO", announceToggleListener);
+	ChatFrame_AddMessageEventFilter("CHAT_MSG_COMBAT_MISC_INFO", announceToggleListener);
+	ChatFrame_AddMessageEventFilter("CHAT_MSG_BG_SYSTEM_HORDE", announceToggleListener);
+	ChatFrame_AddMessageEventFilter("CHAT_MSG_BG_SYSTEM_ALLIANCE", announceToggleListener);
+	ChatFrame_AddMessageEventFilter("CHAT_MSG_BG_SYSTEM_NEUTRAL", announceToggleListener);
+	ChatFrame_AddMessageEventFilter("CHAT_MSG_TARGETICONS", announceToggleListener);
+	ChatFrame_AddMessageEventFilter("CHAT_MSG_BN_CONVERSATION_NOTICE", announceToggleListener);
+end

--- a/_retail_/Interface/AddOns/Epsilon_ChatToggle/Epsilon_ChatToggle.toc
+++ b/_retail_/Interface/AddOns/Epsilon_ChatToggle/Epsilon_ChatToggle.toc
@@ -6,5 +6,6 @@
 ## DefaultState: Enabled
 ## SavedVariables: Epsilon_ChatToggle_Account
 ## SavedVariablesPerCharacter: Epsilon_ChatToggle_Character
+## OptionalDeps: EpsilonLib, EpsilonLib-dev
 
 ChatToggle.lua

--- a/_retail_/Interface/AddOns/Epsilon_Merchant/MerchantFrame.lua
+++ b/_retail_/Interface/AddOns/Epsilon_Merchant/MerchantFrame.lua
@@ -614,7 +614,8 @@ function BuyEpsilon_MerchantItem( itemID, amount )
 			stackCount = 1;
 		end
 
-		SendCommand( "additem " .. itemID .. " " .. ( amount * stackCount ) )
+		--SendCommand( "additem " .. itemID .. " " .. ( amount * stackCount ) )
+		SendCommand( "additem " .. itemID .. " " .. ( amount ) ) -- I can't figure out why but amount is = stackCount when called anyways it seems so just ignore it?
 		C_Timer.After( 0.5, function()
 			Epsilon_Merchant_PlaySound( "buyitem" )
 			Epsilon_MerchantFrame_Update()
@@ -1777,13 +1778,13 @@ function Epsilon_MerchantFrame_ConfirmExtendedItemCost(itemButton, numToPurchase
     end
     return;
   end
-  
+
   Epsilon_MerchantFrame.itemIndex = index;
   Epsilon_MerchantFrame.count = numToPurchase;
-  
+
   local stackCount = itemButton.count or 1;
   numToPurchase = numToPurchase or stackCount;
-  
+
   local maxQuality = 0;
   local usingCurrency = false;
   for i = 1, GetMerchantItemCostInfo(index) do
@@ -1800,7 +1801,7 @@ function Epsilon_MerchantFrame_ConfirmExtendedItemCost(itemButton, numToPurchase
       end
     elseif ( itemLink ) then
       local itemName, itemLink, itemQuality = GetItemInfo(itemLink);
- 
+
       maxQuality = math.max(itemQuality, maxQuality);
       if ( itemsString ) then
         itemsString = itemsString .. LIST_DELIMITER .. format(ITEM_QUANTITY_TEMPLATE, costItemCount, itemLink);
@@ -1820,15 +1821,15 @@ function Epsilon_MerchantFrame_ConfirmExtendedItemCost(itemButton, numToPurchase
       itemsString = GetMoneyString(itemButton.price);
     end
   end
-  
+
   if ( not usingCurrency and maxQuality <= Enum.ItemQuality.Uncommon and not itemButton.showNonrefundablePrompt) or (not itemsString and not itemButton.price) then
     BuyEpsilon_MerchantItem( itemButton:GetID(), numToPurchase );
     return;
   end
-  
+
   local popupData = Epsilon_MerchantFrame_GetProductInfo( itemButton );
   popupData.count = numToPurchase;
-  
+
   if (itemButton.showNonrefundablePrompt) then
     StaticPopup_Show("EPSILON_MERCHANT_CONFIRM_PURCHASE_NONREFUNDABLE_ITEM", itemsString, nil, popupData );
   else
@@ -1845,16 +1846,16 @@ function Epsilon_MerchantFrame_GetProductInfo( itemButton )
   if(itemButton.link) then
     itemName, itemHyperlink, itemQuality = GetItemInfo(itemButton.link);
   end
- 
+
   if ( itemName ) then
     --It's an item
-    r, g, b = GetItemQualityColor(itemQuality); 
+    r, g, b = GetItemQualityColor(itemQuality);
   else
     --Not an item. Could be currency or something. Just use what's on the button.
     itemName = itemButton.name;
-    r, g, b = GetItemQualityColor(1); 
+    r, g, b = GetItemQualityColor(1);
   end
- 
+
   local productInfo = {
     texture = itemButton.texture,
     name = itemName,
@@ -1862,7 +1863,7 @@ function Epsilon_MerchantFrame_GetProductInfo( itemButton )
     link = itemHyperlink,
     index = itemButton:GetID(),
   };
- 
+
   return productInfo;
 end
 
@@ -1871,7 +1872,7 @@ end
 function Epsilon_MerchantFrame_ConfirmHighCostItem(itemButton, quantity)
   quantity = (quantity or 1);
   local index = itemButton:GetID();
- 
+
   Epsilon_MerchantFrame.itemIndex = index;
   Epsilon_MerchantFrame.count = quantity;
   Epsilon_MerchantFrame.price = itemButton.price;

--- a/_retail_/Interface/AddOns/PhaseToolkit/PhaseToolkit.lua
+++ b/_retail_/Interface/AddOns/PhaseToolkit/PhaseToolkit.lua
@@ -509,6 +509,7 @@ PhaseToolkit.InfoCustom = {
 			["Hair"] = 12,
 			["Headdress"] = 3,
 			["Horncolor"] = 16,
+			["Hornstyle"] = 20,
 			["JewelryColor"] = 8,
 			["Mane"] = 5,
 			["Necklace"] = 3,

--- a/_retail_/Interface/AddOns/SpellCreator/UI/SpellRow.lua
+++ b/_retail_/Interface/AddOns/SpellCreator/UI/SpellRow.lua
@@ -378,6 +378,18 @@ local function addRow(rowToAdd, copy)
 		inputEntryBox:SetHyperlinksEnabled(true)
 		local widgetScripts = {
 			OnHyperlinkEnter = function(self, link, text, region, boundsLeft, boundsBottom, boundsWidth, boundsHeight)
+				if link:find("arcSpell:") then
+					local linkType, linkData, displayText = LinkUtil.ExtractLink(text)
+					--print(linkType, linkData, displayText)
+
+					if linkType == "arcSpell" then
+						local spellName = displayText:gsub("%[(.+)%]", "%1")
+						local spellComm, charOrPhase, numActions, spellIcon = strsplit(":", linkData)
+
+						ns.UI.ChatLink.showSpellTooltip(spellComm, spellName, charOrPhase, linkData, nil, self)
+					end
+					return
+				end
 				GameTooltip:SetOwner(self, "ANCHOR_PRESERVE");
 				GameTooltip:ClearAllPoints();
 				local cursorClearance = 30;


### PR DESCRIPTION
## Merchant: 
- Fix Sound Picker not saving / not showing correct Sound Names in current selections
- Fix Adding Items to merchant
- Fix Buying Stacks buying the square of the amount

## EpsiLib: 
- Add Phase Names to Minimap Zone Name Phase Tooltip line

## ChatToggle:
- Use EpsiLib Event Manager

## Phase Toolkit: 
- Fix missing tauren horn style custom

## Arcanum:
- Fixed ArcSpells not able to be linked into an action input box